### PR TITLE
Update niv-updater-action to the latest release

### DIFF
--- a/.github/workflows/niv-updates.yml
+++ b/.github/workflows/niv-updates.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # notice there is no checkout step
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v5
+        uses: knl/niv-updater-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This is to reduce the backreferencing noise on nixpkgs: https://github.com/knl/niv-updater-action/issues/36